### PR TITLE
NPC not responding to message with "hi" (greetwords) in it

### DIFF
--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -220,8 +220,7 @@ if Modules == nil then
 
 	-- Greeting callback function.
 	function FocusModule.onGreet(cid, message, keywords, parameters)
-		parameters.module.npcHandler:onGreet(cid)
-		return true
+		return parameters.module.npcHandler:onGreet(cid)
 	end
 
 	-- UnGreeting callback function.

--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -517,9 +517,10 @@ if NpcHandler == nil then
 		if self:isInRange(cid) then
 			if not self:isFocused(cid) then
 				self:greet(cid)
-				return
+				return true
 			end
 		end
+		return false
 	end
 
 	-- Simply calls the underlying unGreet function.


### PR DESCRIPTION
As some of you know, after the introduction of Jiddo's NPC system, which greatly helped the community, there has been but one bad thing of it becoming a convoluted mess from keeping Mark's 10 year old codebase and re-introducing Jiddo's system. Some of the legacy code is still remaining within TFS, but unused at all.

I will describe a bug remnant from those changes.

### Before creating an issue, please ensure:
- [x] This is a bug in the software that resides in this repository, and not a
      support matter (use https://otland.net/forums/otclient.494/ for support)
- [x] This issue is reproducible without changes to the code in this repository

### Steps to reproduce (include any configuration/script required to reproduce)
1. Say one of the greetwords to an npc.
![image](https://user-images.githubusercontent.com/32970897/230752946-3a7b2d1b-0122-4569-a17f-fd5ac69d4ee2.png)
![image](https://user-images.githubusercontent.com/32970897/230752961-dcfa8fa4-f858-4aa8-a818-2f2d1f9a1ec5.png)

2. Say one of the keywords to the npc, it will work as expected.
![image](https://user-images.githubusercontent.com/32970897/230752968-a0110c8d-36cf-4565-8ea1-0965cc635325.png)

3. If you say that keyword again, but include the word "hi", this time it will not work.
![image](https://user-images.githubusercontent.com/32970897/230753045-83990b7e-8d05-4178-80ea-5b947d8bbc30.png)

4. Or for a better illustrative example, include a word with "hi" inside of it.
![image](https://user-images.githubusercontent.com/32970897/230753086-b6ebe30f-448f-4796-ae44-7f09f853a13b.png)

5. See in the last example, using the words "pink" worked, but "**white**" didn't, because of the "hi" in "w**hi**te".

### Expected behaviour
Should process it in npcsystem

### Actual behaviour
Doesn't

### Proposed fix
![image](https://user-images.githubusercontent.com/32970897/230753435-5e87e638-2b7c-4bde-802f-5aabfc18fce9.png)
![image](https://user-images.githubusercontent.com/32970897/230753446-74c12279-fe0b-4708-8121-ee55412af09b.png)

### Environment
Linux